### PR TITLE
Replace bs4 with beautifulsoup4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bs4
+beautifulsoup4
 colorama
 tabulate
 cmd2


### PR DESCRIPTION
`bs4` is a dummy package which most distributions don't ship.